### PR TITLE
change .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,6 @@ AllCops:
     - 'spec/*.rb'
     - 'config/puma.rb'
   TargetRubyVersion: 2.6.3
+
+  Documentation:
+    Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@
 
 # rubocop:disable Metrics/LineLength
 
+#rubocop：enable Metrics/LineLength
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable LineLength
+# rubocop:disable Metrics/LineLength
 
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.


### PR DESCRIPTION
Missing top-level module documentation comment.
を修正できるか検証中です
。